### PR TITLE
Bugfix: increase outdated flask package version to ~=2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ redis==3.5.3
 alembic==1.3.2
 
 # Flask
-Flask==1.1.1
+Flask~=2.0.0
 Flask-SQLAlchemy==2.4.1
 Flask-json-schema==0.0.5
 Flask-Migrate==2.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ Flask-SQLAlchemy==2.4.1
 Flask-json-schema==0.0.5
 Flask-Migrate==2.5.2
 Flask-HTTPAuth==4.1.0
-Werkzeug==1.0.1
+Werkzeug~=2.0.0
 
 # Misc
 gunicorn==20.1.0


### PR DESCRIPTION
The use of a legacy flask version is resulting in breaking changes due to a new release of `itsdangerous`.
ref: https://github.com/ovh/celery-director/issues/125