### PR TITLE
Docker compose services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ venv/
 
 # Build
 build/
-director.egg-info/
+*.egg-info
 dist/
 
 # Celery

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.8"
+
+volumes:
+  pg-data:
+
+services:
+  redis:
+    image: redis:latest
+    restart: always
+    ports:
+      - "6379:6379"
+
+  postgres:
+    image: postgres:13
+    ports:
+      - "5432:5432"
+    volumes:
+      - pg-data:/var/lib/postgresql/data/
+    environment:
+      - POSTGRES_USER=postgres_user
+      - POSTGRES_PASSWORD=postgres_pass
+      - POSTGRES_PORT=5432
+      - POSTGRES_DB=director_db

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,14 +7,28 @@ To test Celery Director in real conditions we decided to use an executing `worke
 $ (venv) git clone https://github.com/ovh/director && cd director
 $ (venv) python setup.py develop
 $ (venv) export DIRECTOR_HOME=`pwd`/tests/workflows/
+$ (venv) docker-compose up -d redis postgres
 $ (venv) director celery worker -P solo -D
 ```
 
 Configuration (database, redis...) can be customized in the `$DIRECTOR_HOME/.env` file.
+
+```
+# postgres director database uri
+DIRECTOR_DATABASE_URI=postgresql://postgres_user:postgres_pass@localhost:5432/director_db
+# redis celery broker database uri
+DIRECTOR_BROKER_URI=redis://localhost:6379/0
+```
 
 You can then launch the tests in another terminal :
 
 ```
 $ pip install pytest==5.3.5
 $ pytest tests/ -v
+```
+
+kill all celery workers :
+
+```
+$ pkill -9 -f 'celery'
 ```


### PR DESCRIPTION
Adding a docker-compose file for redis and postgres services.
Useful for running tests locally and creating database migrations