### PR TITLE
Bugfix: Adding a check to task prerun for internal celery tasks

### DIFF
--- a/director/exceptions.py
+++ b/director/exceptions.py
@@ -16,3 +16,7 @@ class WorkflowSyntaxError(Exception):
 
 class UserNotFound(Exception):
     pass
+
+
+class TaskNotFound(Exception):
+    pass

--- a/director/tasks/base.py
+++ b/director/tasks/base.py
@@ -3,21 +3,25 @@ from celery.signals import after_task_publish, task_prerun, task_postrun
 from celery.utils.log import get_task_logger
 
 from director.extensions import cel, db
+from director.exceptions import TaskNotFound
 from director.models import StatusType
 from director.models.workflows import Workflow
 from director.models.tasks import Task
-
 
 logger = get_task_logger(__name__)
 
 
 @task_prerun.connect
 def director_prerun(task_id, task, *args, **kwargs):
-    if task.name.startswith("director.tasks"):
+    ignored_tasks = ("director.tasks", "celery.")
+    if task.name.startswith(ignored_tasks):
         return
 
     with cel.app.app_context():
+        logger.info("task_id: %s", task_id)
         task = Task.query.filter_by(id=task_id).first()
+        if not task:
+            raise TaskNotFound(f"Task {task_id} not found")
         task.status = StatusType.progress
         task.save()
 


### PR DESCRIPTION
Celery chord callbacks (groups) work differently with redis result backends
vs postgres/rabbit result backends, this results in an exception being
thrown in the director task prerun handler due to a task_id not
existing for the director postgres database

ref:
http://blog.untrod.com/2015/03/how-celery-chord-synchronization-works.html
https://linius.atlassian.net/browse/DL-381