### PR TITLE
Adding the ability to define workflows in YAML or JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ def send_mail(*args, **kwargs):
     mail.send()
 ```
 
-### Build your workflows in YAML
+### Build your workflows in YAML or JSON
+```bash
+export DIRECTOR_WORKFLOW_FORMAT=json
+```
 
 ```yaml
 # workflows.yml
@@ -68,6 +71,18 @@ product.ORDER:
   tasks:
     - ORDER_PRODUCT
     - SEND_MAIL
+```
+
+```json
+# workflows.json
+{
+    "product.ORDER": {
+        "tasks": [
+            "ORDER_PRODUCT",
+            "SEND_MAIL"
+        ]
+    }
+}
 ```
 
 ### Run it
@@ -92,7 +107,8 @@ Read the [documentation](https://ovh.github.io/celery-director/) to try the quic
 ## Project layout
 
     .env                # The configuration file.
-    workflows.yml       # The workflows definition.
+    workflows.yml       # The yaml workflows definition.
+    workflows.json      # The json workflows definition.
     tasks/
         example.py      # A file containing some tasks.
         ...             # Other files containing other tasks.

--- a/director/settings.py
+++ b/director/settings.py
@@ -76,6 +76,7 @@ class Config(object):
         # static workflow file format
         self.WORKFLOW_FORMAT = env.str("DIRECTOR_WORKFLOW_FORMAT", "yaml").lower()
 
+
 class UserConfig(dict):
     """Handle the user configuration"""
 

--- a/director/settings.py
+++ b/director/settings.py
@@ -73,6 +73,8 @@ class Config(object):
         # Default retention value (number of workflows to keep in the database)
         self.DEFAULT_RETENTION_OFFSET = env.int("DIRECTOR_DEFAULT_RETENTION_OFFSET", -1)
 
+        # static workflow file format
+        self.WORKFLOW_FORMAT = env.str("DIRECTOR_WORKFLOW_FORMAT", "yaml").lower()
 
 class UserConfig(dict):
     """Handle the user configuration"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,10 @@ def no_worker(monkeypatch):
 def create_builder(app):
     def _create_builder(project, name, payload, periodic=False, keys=KEYS_TO_REMOVE):
         with app.app_context():
-            # TODO: Implement better patching
+            # TODO: investigate the root cause of this issue and implement fix
+            # The current implementation of initializing a flask_app fixture is
+            # performed before the test logic runs, we are therefore unable
+            # to update any of the app config without calling extension.app_init
             from director.extensions import cel_workflows
             cel_workflows.init_app(app)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,9 +95,11 @@ def no_worker(monkeypatch):
 def create_builder(app):
     def _create_builder(project, name, payload, periodic=False, keys=KEYS_TO_REMOVE):
         with app.app_context():
-            obj = Workflow(
-                project=project, name=name, payload=payload, periodic=periodic
-            )
+            # TODO: Implement better patching
+            from director.extensions import cel_workflows
+            cel_workflows.init_app(app)
+
+            obj = Workflow(project=project, name=name, payload=payload, periodic=periodic)
             obj.save()
             data = obj.to_dict()
             wf = WorkflowBuilder(obj.id)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,21 +1,26 @@
+import os
 from uuid import UUID
-
 import pytest
 
 from director.exceptions import WorkflowNotFound
 from director.tasks.workflows import start, end
 from director.models.tasks import Task
 from director.models.workflows import Workflow
+from director.settings import Config
 
 from tests.conftest import _remove_keys
 
 
-def test_create_unknown_workflow(create_builder):
+@pytest.mark.parametrize("workflow_fmt", [('yaml'), ('json')])
+def test_create_unknown_workflow(app, create_builder, workflow_fmt):
+    app.config["WORKFLOW_FORMAT"] = workflow_fmt
     with pytest.raises(WorkflowNotFound):
         create_builder("project", "UNKNOW_WORKFLOW", {})
 
 
-def test_build_one_task(create_builder):
+@pytest.mark.parametrize("workflow_fmt", [('yaml'), ('json')])
+def test_build_one_task(app, create_builder, workflow_fmt):
+    app.config["WORKFLOW_FORMAT"] = workflow_fmt
     data, builder = create_builder("example", "WORKFLOW", {"foo": "bar"})
     assert data == {
         "name": "WORKFLOW",
@@ -32,7 +37,9 @@ def test_build_one_task(create_builder):
     assert builder.canvas[1].task == "TASK_EXAMPLE"
 
 
-def test_build_chained_tasks(app, create_builder):
+@pytest.mark.parametrize("workflow_fmt", [('yaml'), ('json')])
+def test_build_chained_tasks(app, create_builder, workflow_fmt):
+    app.config["WORKFLOW_FORMAT"] = workflow_fmt
     keys = ["id", "created", "updated", "task"]
     data, builder = create_builder("example", "SIMPLE_CHAIN", {"foo": "bar"})
     assert data == {
@@ -76,8 +83,9 @@ def test_build_chained_tasks(app, create_builder):
         "status": "pending",
     }
 
-
-def test_build_grouped_tasks(app, create_builder):
+@pytest.mark.parametrize("workflow_fmt", [('yaml'), ('json')])
+def test_build_grouped_tasks(app, create_builder, workflow_fmt):
+    app.config["WORKFLOW_FORMAT"] = workflow_fmt
     keys = ["id", "created", "updated", "task"]
     data, builder = create_builder("example", "SIMPLE_GROUP", {"foo": "bar"})
     assert data == {

--- a/tests/workflows/workflows.json
+++ b/tests/workflows/workflows.json
@@ -1,0 +1,87 @@
+{
+    "example.WORKFLOW": {
+        "tasks": [
+            "TASK_EXAMPLE"
+        ]
+    },
+    "example.SIMPLE_CHAIN": {
+        "tasks": [
+            "TASK_A",
+            "TASK_B",
+            "TASK_C"
+        ]
+    },
+    "example.SIMPLE_GROUP": {
+        "tasks": [
+            "TASK_A",
+            {
+                "EXAMPLE_GROUP": {
+                    "type": "group",
+                    "tasks": [
+                        "TASK_B",
+                        "TASK_C"
+                    ]
+                }
+            }
+        ]
+    },
+    "example.ERROR": {
+        "tasks": [
+            "TASK_ERROR"
+        ]
+    },
+    "example.SIMPLE_CHAIN_ERROR": {
+        "tasks": [
+            "TASK_A",
+            "TASK_B",
+            "TASK_ERROR"
+        ]
+    },
+    "example.SIMPLE_GROUP_ERROR": {
+        "tasks": [
+            "TASK_A",
+            {
+                "EXAMPLE_GROUP": {
+                    "type": "group",
+                    "tasks": [
+                        "TASK_ERROR",
+                        "TASK_C"
+                    ]
+                }
+            }
+        ]
+    },
+    "schemas.SIMPLE_SCHEMA": {
+        "tasks": [
+            "TASK_EXAMPLE"
+        ],
+        "schema": "example/simple_schema"
+    },
+    "example.CELERY_ERROR_ONE_TASK": {
+        "tasks": [
+            "TASK_CELERY_ERROR"
+        ]
+    },
+    "example.CELERY_ERROR_MULTIPLE_TASKS": {
+        "tasks": [
+            "TASK_A",
+            "TASK_CELERY_ERROR"
+        ]
+    },
+    "example.RETURN_VALUES": {
+        "tasks": [
+            "STR",
+            "INT",
+            "LIST",
+            "NONE",
+            "DICT",
+            "NESTED"
+        ]
+    },
+    "example.RETURN_EXCEPTION": {
+        "tasks": [
+            "STR",
+            "TASK_ERROR"
+        ]
+    }
+}


### PR DESCRIPTION
Currently celery director workflows are only defined using YAML,
this is limiting for more complex workflows with options like
per task queues and retry logic, it also prevents us from being
able to dynamically send in workflows which is a desirable feature to have.

I will retain the existing YAML functionality as the default behaviour
whilst adding the ability to switch to json based on as setting:

i.e: `export DIRECTOR_WORKFLOW_FORMAT=json`

ref: https://linius.atlassian.net/browse/DL-382