### PR TITLE
Bugfix: updating flask package version and dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,18 +12,18 @@ redis==3.3.11
 alembic==1.3.2
 
 # Flask
-Flask==1.1.1
+Flask~=2.0.0
 Flask-SQLAlchemy==2.4.1
 Flask-json-schema==0.0.5
 Flask-Migrate==2.5.2
 Flask-HTTPAuth==4.1.0
-Werkzeug==1.0.1
+Werkzeug~=2.0.0
 
 # Misc
 gunicorn==20.0.4
 environs==6.1.0
 pyyaml==5.4.1
-click==7.0
+click>=7.1.2
 terminaltables==3.1.0
 pluginbase==1.0.0
 sentry-sdk==0.16.3


### PR DESCRIPTION
ref issue: https://github.com/ovh/celery-director/issues/125

- Flask upgraded from `==1.1.1` to `~=2.0.0`
- Werkzeug upgraded from `==1.0.1` to `~=2.0.0`
- click upgraded from `==7.0` to `>=7.1.2`

Signed-off-by: George Eddie geddie@linius.com